### PR TITLE
Bug fix:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,7 +543,7 @@
 		<profile>
 			<id>java8-disable-doclint</id>
 			<activation>
-				<jdk>[1.8,</jdk>
+				<jdk>[1.8,]</jdk>
 			</activation>
 			<build>
 				<plugins>


### PR DESCRIPTION
java8-disable-doclint plugin had a typo. Changed from '[1.8,' to '[1.8,]'. Intellij IDEA can't read the pom this way.

See also http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete
